### PR TITLE
feat: optimize typescript query

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -15,7 +15,7 @@ export class Constants {
   (variable_declarator 
     name: [(identifier) @var-def
     (array_pattern (identifier) @var-def)]
-    type: (type_annotation)* @type-ref)
+    type: (type_annotation)? @type-ref)
   (call_expression
     function: [
       (identifier) @function-ref
@@ -23,45 +23,44 @@ export class Constants {
         object: [(identifier) (non_null_expression)] @method-obj
         property: (property_identifier) @method-ref)
     ]
-    arguments: (arguments (identifier)@var-ref)*
+    arguments: (arguments (identifier) @var-ref)*
   )
   (member_expression property: (property_identifier) @field-ref)
-  (assignment_expression left:(identifier)@var-ref)
-  
+  (assignment_expression left: (identifier) @var-ref)
   (new_expression
-    constructor:(identifier)@type-ref
+    constructor: (identifier) @type-ref
   )
-  (predefined_type)@type-ref
-  (array_type (type_identifier)@type-ref)
+  (predefined_type) @type-ref
+  (array_type (type_identifier) @type-ref)
   (comment) @comment
-  (for_in_statement right:(identifier)@var-ref)
+  (for_in_statement right: (identifier) @var-ref)
   (member_expression 
-    object:(identifier)@var-ref
-    property:(property_identifier))
+    object: (identifier) @var-ref
+    property: (property_identifier))
   (subscript_expression
-    object: (identifier)@var-ref
-    index: (identifier)*@var-ref
+    object: (identifier) @var-ref
+    index: (identifier)? @var-ref
   )
   (binary_expression
-    left:(identifier)*@var-ref
-    right:(identifier)*@var-ref
+    left: (identifier)? @var-ref
+    right: (identifier)? @var-ref
   )
-  (type_annotation (type_identifier)@type-ref)
-  (unary_expression argument:(identifier)@var-ref)
-  (type_alias_declaration name:(type_identifier)@type-def)
-  (type_annotation [(generic_type (type_identifier)@type-ref)
-    (tuple_type (type_identifier)@type-ref)])
-  (arguments (identifier)@var-ref)
-  (type_arguments (type_identifier)@type-ref)
+  (type_annotation (type_identifier) @type-ref)
+  (unary_expression argument: (identifier) @var-ref)
+  (type_alias_declaration name: (type_identifier) @type-def)
+  (type_annotation [(generic_type (type_identifier) @type-ref)
+    (tuple_type (type_identifier) @type-ref)])
+  (arguments (identifier) @var-ref)
+  (type_arguments (type_identifier) @type-ref)
   (as_expression 
-    (identifier)*@var-ref
-    (type_identifier)*@type-ref)
-  (parenthesized_expression (identifier)@var-ref)
+    (identifier)? @var-ref
+    (type_identifier)? @type-ref)
+  (parenthesized_expression (identifier) @var-ref)
   (assignment_expression 
-    left: (identifier)*@var-ref
-    right: (identifier)*@var-ref
+    left: (identifier)? @var-ref
+    right: (identifier)? @var-ref
   )
-  (return_statement (identifier)@var-ref)
+  (return_statement (identifier) @var-ref)
   `
 
   public static javaScriptQuery: string = ''

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -12,10 +12,15 @@ export class Constants {
   (labeled_statement label: (statement_identifier) @field-def)
   (function_declaration name: (identifier) @function-def)
   (method_definition name: (property_identifier) @method-def)
-  (variable_declarator 
-    name: [(identifier) @var-def
-    (array_pattern (identifier) @var-def)]
-    type: (type_annotation)? @type-ref)
+  (variable_declarator
+    name: (identifier) @var-def
+    type: (type_annotation)? @type-ref
+  )
+  (array_pattern (identifier) @var-def)
+  (object_pattern [
+    (pair_pattern value: (identifier) @var-def)
+    (shorthand_property_identifier_pattern) @var-def
+  ])
   (call_expression
     function: [
       (identifier) @function-ref

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -34,9 +34,10 @@ export class Constants {
   (array_type (type_identifier) @type-ref)
   (comment) @comment
   (for_in_statement right: (identifier) @var-ref)
-  (member_expression 
+  (member_expression
     object: (identifier) @var-ref
-    property: (property_identifier))
+    property: (property_identifier)
+  )
   (subscript_expression
     object: (identifier) @var-ref
     index: (identifier)? @var-ref
@@ -52,11 +53,21 @@ export class Constants {
     (tuple_type (type_identifier) @type-ref)])
   (arguments (identifier) @var-ref)
   (type_arguments (type_identifier) @type-ref)
-  (as_expression 
+  (as_expression
     (identifier)? @var-ref
-    (type_identifier)? @type-ref)
+    (type_identifier)? @type-ref
+  )
   (parenthesized_expression (identifier) @var-ref)
-  (assignment_expression 
+  (assignment_expression
+    left: (identifier)? @var-ref
+    right: (identifier)? @var-ref
+  )
+  (ternary_expression
+    condition: (identifier)? @var-ref
+    consequence: (identifier)? @var-ref
+    alternative: (identifier)? @var-ref
+  )
+  (sequence_expression
     left: (identifier)? @var-ref
     right: (identifier)? @var-ref
   )
@@ -71,7 +82,7 @@ export class Constants {
   (field_access field: (identifier) @field-ref)
   (method_declaration name: (identifier) @method-def)
   (method_invocation name: (identifier) @method-ref)
-  (local_variable_declaration type: (type_identifier) @type-ref 
+  (local_variable_declaration type: (type_identifier) @type-ref
   declarator: (variable_declarator name: (identifier)) @var-def)
   (object_creation_expression type: (type_identifier) @type-ref)
   (type_arguments (type_identifier) @type-ref)

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -11,6 +11,7 @@ export class Constants {
   (public_field_definition name: (property_identifier) @field-def)
   (labeled_statement label: (statement_identifier) @field-def)
   (function_declaration name: (identifier) @function-def)
+  (generator_function_declaration name: (identifier) @function-def)
   (method_definition name: (property_identifier) @method-def)
   (variable_declarator
     name: (identifier) @var-def
@@ -76,6 +77,7 @@ export class Constants {
     left: (identifier)? @var-ref
     right: (identifier)? @var-ref
   )
+  (yield_expression (identifier) @var-ref)
   (return_statement (identifier) @var-ref)
   `
 


### PR DESCRIPTION
Changes:

- 调整了部分书写和表达顺序
- 将部分数量限定符 `*` 修改为 `?`
- 支持了下列语法：
  - sequence_expression
  - ternary_expression
  - yield_expression
  - generator_function_declaration
  - object_pattern 和嵌套的 array_pattern

Note：如果把 `(identifier)` 放最后兜底，直接可以省掉一大半语法。理论上不可以，因为这样会导致 def/ref 混乱，但问题是目前的 query 似乎也没好到哪里去？如果不能解决 block 引用的问题的话，那这样做的损失其实可以忽略了。

Note2：non_null_expression 我不知道是什么……有人能告诉我一下吗？
