### PR TITLE
feat: update js/ts query

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -10,6 +10,7 @@ export class Constants {
   (comment) @comment
   (class_declaration name: (type_identifier) @type-def)
   (type_alias_declaration name: (type_identifier) @type-def)
+  (interface_declaration name: (type_identifier) @type-def)
   (public_field_definition name: (property_identifier) @field-def)
   (labeled_statement label: (statement_identifier) @field-def)
   (function_declaration name: (identifier) @function-def)
@@ -25,6 +26,7 @@ export class Constants {
     (pair_pattern value: (identifier) @var-def)
     (shorthand_property_identifier_pattern) @var-def
   ])
+  (internal_module (identifier) @var-def)
   (call_expression
     function: [
       (identifier) @function-ref

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -7,7 +7,9 @@ export class Constants {
   public static conflictMarkerEnd: string = '>>>>>>>'
 
   public static typeScriptQuery: string = `
+  (comment) @comment
   (class_declaration name: (type_identifier) @type-def)
+  (type_alias_declaration name: (type_identifier) @type-def)
   (public_field_definition name: (property_identifier) @field-def)
   (labeled_statement label: (statement_identifier) @field-def)
   (function_declaration name: (identifier) @function-def)
@@ -17,6 +19,7 @@ export class Constants {
     name: (identifier) @var-def
     type: (type_annotation)? @type-ref
   )
+  (for_in_statement left: (identifier) @var-def)
   (array_pattern (identifier) @var-def)
   (object_pattern [
     (pair_pattern value: (identifier) @var-def)
@@ -29,67 +32,29 @@ export class Constants {
         object: [(identifier) (non_null_expression)] @method-obj
         property: (property_identifier) @method-ref)
     ]
-    arguments: (arguments (identifier) @var-ref)*
   )
   (member_expression property: (property_identifier) @field-ref)
-  (assignment_expression left: (identifier) @var-ref)
   (new_expression
     constructor: (identifier) @type-ref
   )
-  (predefined_type) @type-ref
-  (array_type (type_identifier) @type-ref)
-  (comment) @comment
-  (for_in_statement right: (identifier) @var-ref)
-  (member_expression
-    object: (identifier) @var-ref
-    property: (property_identifier)
-  )
-  (subscript_expression
-    object: (identifier) @var-ref
-    index: (identifier)? @var-ref
-  )
-  (binary_expression
-    left: (identifier)? @var-ref
-    right: (identifier)? @var-ref
-  )
-  (type_annotation (type_identifier) @type-ref)
-  (unary_expression argument: (identifier) @var-ref)
-  (type_alias_declaration name: (type_identifier) @type-def)
-  (type_annotation [(generic_type (type_identifier) @type-ref)
-    (tuple_type (type_identifier) @type-ref)])
-  (arguments (identifier) @var-ref)
-  (type_arguments (type_identifier) @type-ref)
-  (as_expression
-    (identifier)? @var-ref
-    (type_identifier)? @type-ref
-  )
-  (parenthesized_expression (identifier) @var-ref)
-  (assignment_expression
-    left: (identifier)? @var-ref
-    right: (identifier)? @var-ref
-  )
-  (ternary_expression
-    condition: (identifier)? @var-ref
-    consequence: (identifier)? @var-ref
-    alternative: (identifier)? @var-ref
-  )
-  (sequence_expression
-    left: (identifier)? @var-ref
-    right: (identifier)? @var-ref
-  )
-  (yield_expression (identifier) @var-ref)
-  (return_statement (identifier) @var-ref)
+  (type_identifier) @type-ref
+  (identifier) @var-ref
   `
 
   public static javaScriptQuery: string = `
+  (comment) @comment
   (class_declaration name: (identifier) @type-def)
   (public_field_definition name: (property_identifier) @field-def)
   (labeled_statement label: (statement_identifier) @field-def)
   (function_declaration name: (identifier) @function-def)
   (method_definition name: (property_identifier) @method-def)
-  (variable_declarator 
-    name: [(identifier) @var-def
-    (array_pattern (identifier) @var-def)]
+  (variable_declarator name: (identifier) @var-def)
+  (for_in_statement left: (identifier) @var-def)
+  (array_pattern (identifier) @var-def)
+  (object_pattern [
+    (pair_pattern value: (identifier) @var-def)
+    (shorthand_property_identifier_pattern) @var-def
+  ])
   (call_expression
     function: [
       (identifier) @function-ref
@@ -97,34 +62,13 @@ export class Constants {
         object: (identifier) @method-obj
         property: (property_identifier) @method-ref)
     ]
-    arguments: (arguments (identifier) @var-ref)*
   )
   (new_expression
     constructor: (identifier) @type-ref
   )
   (member_expression property: (property_identifier) @field-ref)
-  (member_expression 
-    object: (identifier) @var-ref
-    property: (property_identifier))
-  (assignment_expression left: (identifier) @var-ref)
-  (assignment_expression 
-    left: (identifier)* @var-ref
-    right: (identifier)* @var-ref
-  )
-  (comment) @comment
-  (for_in_statement right: (identifier) @var-ref)
-  (subscript_expression
-    object: (identifier) @var-ref
-    index: (identifier)* @var-ref
-  )
-  (unary_expression argument: (identifier) @var-ref)
-  (binary_expression
-    left: (identifier)* @var-ref
-    right: (identifier)* @var-ref
-  )
-  (arguments (identifier) @var-ref)
-  (parenthesized_expression (identifier) @var-ref)
-  (return_statement (identifier) @var-ref)`
+  (identifier) @var-ref
+  `
 
   public static javaQuery: string = `
   (class_declaration name: (identifier) @type-def)


### PR DESCRIPTION
- 按照之前讨论的结果使用 type_identifier / identifier 兜底，大幅简化了 query 书写
- 支持了 for .. of / for .. in / for await .. of 中的 pattern 和 identifier
- 支持了 ts 中的 interface 和 namespace